### PR TITLE
fix: account/egress/get handler configuration

### DIFF
--- a/deploy/app/external.tf
+++ b/deploy/app/external.tf
@@ -44,6 +44,7 @@ data "aws_iam_policy_document" "task_external_dynamodb_scan_query_document" {
     actions = [
       "dynamodb:Scan",
       "dynamodb:Query",
+      "dynamodb:GetItem",
     ]
     resources = [
       data.aws_dynamodb_table.storage_provider_table.arn,

--- a/internal/presets/principal_resolver.go
+++ b/internal/presets/principal_resolver.go
@@ -13,6 +13,8 @@ var principalMapping = map[string]string{
 	"did:web:staging.registrar.warm.storacha.network": "did:key:z6MkuQ8PfSMrzXCwZkbQv662nZC4FGGm1aucbH256HXXZyxo",
 	"did:web:indexer.forge.storacha.network":          "did:key:z6Mkj8WmJQRy5jEnFN97uuc2qsjFdsYCuD5wE384Z1AMCFN7",
 	"did:web:staging.indexer.warm.storacha.network":   "did:key:z6Mkr4QkdinnXQmJ9JdnzwhcEjR8nMnuVPEwREyh9jp2Pb7k",
+	"did:web:up.forge.storacha.network":               "did:key:z6MkgSttS3n3R56yGX2Eufvbwc58fphomhAsLoBCZpZJzQbr",
+	"did:web:staging.up.warm.storacha.network":        "did:key:z6MkpR58oZpK7L3cdZZciKT25ynGro7RZm6boFouWQ7AzF7v",
 }
 
 type resolver struct {


### PR DESCRIPTION
Ref. https://github.com/storacha/project-tracking/issues/619

Fixes and tweaks found when testing the new `account/egress/get` handler.

More specifically:
- adds a custom principal parser so that the verifier can work with RSA keys, which is the type of key generated in the browser. By default, go-ucanto verifiers only support Ed25519 keys.
- allows the service to do `dynamodb:GetItem` on the customers table, required for the new `CustomerTable.Has` method.
- adds presets for resolution of the upload service principals, required during verification of incoming invocations because the ucanto server is configured to trust attestations from the upload service but it needs its keys to resolve properly.
- adds a CORS middleware to the HTTP server so that the dashboard webapp can invoke `account/egress/get`, similar to what the upload service does.