### PR TITLE
chore: consolidation time metric

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/ipfs/go-cid v0.5.0
 	github.com/ipfs/go-log/v2 v2.7.0
 	github.com/ipld/go-ipld-prime v0.21.1-0.20240917223228-6148356a4c2e
+	github.com/multiformats/go-multihash v0.2.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
@@ -20,6 +21,7 @@ require (
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.60.0
 	go.opentelemetry.io/otel/metric v1.38.0
+	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 )
 
@@ -89,7 +91,6 @@ require (
 	github.com/multiformats/go-multiaddr v0.16.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.1 // indirect
-	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.23.4 // indirect
@@ -116,7 +117,6 @@ require (
 	github.com/ucan-wg/go-ucan v0.0.0-20240916120445-37f52863156c // indirect
 	github.com/whyrusleeping/cbor-gen v0.3.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/mock v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/ipfs/go-cid v0.5.0
 	github.com/ipfs/go-log/v2 v2.7.0
 	github.com/ipld/go-ipld-prime v0.21.1-0.20240917223228-6148356a4c2e
-	github.com/multiformats/go-multihash v0.2.3
 	github.com/prometheus/client_golang v1.23.2
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
@@ -91,6 +90,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.16.0 // indirect
 	github.com/multiformats/go-multibase v0.2.0 // indirect
 	github.com/multiformats/go-multicodec v0.9.1 // indirect
+	github.com/multiformats/go-multihash v0.2.3 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo/v2 v2.23.4 // indirect

--- a/internal/consolidator/consolidator.go
+++ b/internal/consolidator/consolidator.go
@@ -148,6 +148,13 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 	// Environment attribute for metrics
 	envAttr := attribute.String("env", c.environment)
 
+	// Track consolidation run duration
+	startTime := time.Now()
+	defer func() {
+		durationMs := time.Since(startTime).Milliseconds()
+		metrics.ConsolidationRunDuration.Record(ctx, durationMs, metric.WithAttributeSet(attribute.NewSet(envAttr)))
+	}()
+
 	// Get unprocessed records
 	records, err := c.egressTable.GetUnprocessed(ctx, c.batchSize)
 	if err != nil {

--- a/internal/consolidator/consolidator_test.go
+++ b/internal/consolidator/consolidator_test.go
@@ -83,7 +83,6 @@ func TestValidateRetrievalReceipt(t *testing.T) {
 	// Create a consolidator instance to test the validation context it creates works as expected
 	c, err := New(
 		consolidatorID,
-		"test",
 		nil,
 		nil,
 		nil,

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
-	semconv "go.opentelemetry.io/otel/semconv/v1.24.0"
 )
 
 var log = logging.Logger("metrics")
@@ -37,10 +36,7 @@ func Init(environment string) error {
 	}
 
 	// Create a resource with the environment attribute
-	res := resource.NewWithAttributes(
-		semconv.SchemaURL,
-		attribute.String("env", environment),
-	)
+	res := resource.NewSchemaless(attribute.String("env", environment))
 
 	// Create a MeterProvider with the Prometheus exporter and resource
 	provider := sdkmetric.NewMeterProvider(

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -21,6 +21,9 @@ var (
 
 	// UnprocessedBatches keeps track of the total number of batches pending consolidation
 	UnprocessedBatches metric.Int64UpDownCounter
+
+	// ConsolidationRunDuration tracks the time (in milliseconds) each consolidation run takes to process all batches
+	ConsolidationRunDuration metric.Int64Histogram
 )
 
 // Init initializes the OpenTelemetry metrics with Prometheus exporter
@@ -62,6 +65,14 @@ func Init() error {
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create UnprocessedBatches counter: %w", err)
+	}
+
+	ConsolidationRunDuration, err = meter.Int64Histogram(
+		"etracker_consolidation_run_duration_ms",
+		metric.WithDescription("Time in milliseconds for each consolidation run to process all batches"),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create ConsolidationRunDuration histogram: %w", err)
 	}
 
 	log.Info("OpenTelemetry metrics initialized with Prometheus exporter")

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -107,7 +107,6 @@ type Service interface {
 
 type service struct {
 	id                   principal.Signer
-	environment          string
 	egressTable          egress.EgressTable
 	consolidatedTable    consolidated.ConsolidatedTable
 	storageProviderTable storageproviders.StorageProviderTable
@@ -118,7 +117,6 @@ type service struct {
 
 func New(
 	id principal.Signer,
-	environment string,
 	egressTable egress.EgressTable,
 	consolidatedTable consolidated.ConsolidatedTable,
 	storageProviderTable storageproviders.StorageProviderTable,
@@ -128,7 +126,6 @@ func New(
 ) (*service, error) {
 	return &service{
 		id:                   id,
-		environment:          environment,
 		egressTable:          egressTable,
 		consolidatedTable:    consolidatedTable,
 		storageProviderTable: storageProviderTable,
@@ -144,9 +141,8 @@ func (s *service) Record(ctx context.Context, node did.DID, receipts ucan.Link, 
 	}
 
 	nodeAttr := attribute.String("node", node.String())
-	envAttr := attribute.String("env", s.environment)
-	metrics.TrackedBatchesPerNode.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(nodeAttr, envAttr)))
-	metrics.UnprocessedBatches.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(envAttr)))
+	metrics.TrackedBatchesPerNode.Add(ctx, 1, metric.WithAttributeSet(attribute.NewSet(nodeAttr)))
+	metrics.UnprocessedBatches.Add(ctx, 1)
 
 	return nil
 }


### PR DESCRIPTION
Ref. #31 

Add a histogram to track the consolidation runs take, to prevent potential issues with consolidation cycles taking too long and overlapping each other.

As a drive-by refactor, the environment attribute is now added to the provider in a resource. This is done once when initializing metrics and avoids the need to add the attribute on each metric call.