### PR TITLE
fix: do not mark a record as processed if it was not processed successfully

### DIFF
--- a/internal/consolidator/consolidator.go
+++ b/internal/consolidator/consolidator.go
@@ -162,6 +162,7 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 	log.Infof("Processing %d unprocessed records", len(records))
 
 	// Process each record (each record represents a batch of receipts for a single node)
+	successfulRecords := make([]egress.EgressRecord, 0, len(records))
 	for _, record := range records {
 		var rcpt capegress.ConsolidateReceipt
 		totalEgress := uint64(0)
@@ -203,6 +204,8 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 
 		rcpt, err = c.execConsolidateInvocation(ctx, consolidateInv)
 		if err != nil {
+			bLog.Errorf("executing consolidation invocation: %v", err)
+
 			rcpt, err = c.issueErrorReceipt(consolidateInv, capegress.NewConsolidateError(err.Error()))
 			if err != nil {
 				bLog.Errorf("issuing error receipt: %v", err)
@@ -213,7 +216,7 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 		o, x := result.Unwrap(rcpt.Out())
 		var emptyErr capegress.ConsolidateError
 		if x != emptyErr {
-			bLog.Errorf("invocation failed: %s", x.Message)
+			bLog.Errorf("consolidation error: %s", x.Message)
 		} else {
 			totalEgress = o.TotalEgress
 		}
@@ -224,6 +227,8 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 			continue
 		}
 
+		successfulRecords = append(successfulRecords, record)
+
 		// Increment consolidated bytes counter for this node
 		nodeAttr := attribute.String("node", record.Node.String())
 		metrics.ConsolidatedBytesPerNode.Add(ctx, int64(totalEgress), metric.WithAttributeSet(attribute.NewSet(nodeAttr, envAttr)))
@@ -232,13 +237,13 @@ func (c *Consolidator) Consolidate(ctx context.Context) error {
 	}
 
 	// Mark records as processed
-	if err := c.egressTable.MarkAsProcessed(ctx, records); err != nil {
+	if err := c.egressTable.MarkAsProcessed(ctx, successfulRecords); err != nil {
 		return fmt.Errorf("marking records as processed: %w", err)
 	}
 
-	metrics.UnprocessedBatches.Add(ctx, int64(-len(records)), metric.WithAttributeSet(attribute.NewSet(envAttr)))
+	metrics.UnprocessedBatches.Add(ctx, int64(-len(successfulRecords)), metric.WithAttributeSet(attribute.NewSet(envAttr)))
 
-	log.Infof("Consolidation cycle completed. Processed %d records", len(records))
+	log.Infof("Consolidation cycle completed. Processed %d records (%d successful)", len(records), len(successfulRecords))
 
 	return nil
 }


### PR DESCRIPTION
Ref. #11 

In the current implementation, errors are logged but discarded, and the affected batches will be marked as processed and never retried again. After these changes, only batches that have been processed successfully will be marked as processed.

Most errors are retry-able and should work if given another chance, but there will always be batches that will never succeed for some reason or another. The implementation in this PR is naive and doesn't take care of that. A more robust approach would track the number of retries and send batches hitting the limit to a dead letter table of sorts. I think using a job queue on SQS to process batches would allow continuous consolidation and give us builtin retries and dead letter, I'll explore that path.