### PR TITLE
fix: add temporary test zone (cost-analysis)

### DIFF
--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -56,7 +56,7 @@ module "shared" {
   }
   create_db = false
   caches = []
-  networks = ["warm","forge"]
+  networks = ["warm","forge","test"]
   app = var.app
   create_shared_dev_resources = var.create_shared_dev_resources
   zone_id = var.cloudflare_zone_id


### PR DESCRIPTION
Add the `test` zone (used for cost analysis) to shared to prevent it from being removed on deployments.