### PR TITLE
feat: allow requesting egress data for a full year

### DIFF
--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -265,7 +265,7 @@ func (s *service) getAccountStats(
 	return stats, err
 }
 
-const maxPeriodDays = 60
+const maxPeriodDays = 365
 
 // defaultPeriod returns a period from the first day of the last complete month to today
 func defaultPeriod() Period {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -244,7 +244,7 @@ func TestGetAccountEgress(t *testing.T) {
 		require.ErrorAs(t, err, &periodErr)
 	})
 
-	t.Run("returns period not acceptable error when period exceeds 60 days", func(t *testing.T) {
+	t.Run("returns period not acceptable error when period exceeds 365 days", func(t *testing.T) {
 		accountDID := testutil.RandomDID(t)
 		space := testutil.RandomDID(t)
 
@@ -266,7 +266,7 @@ func TestGetAccountEgress(t *testing.T) {
 		}
 
 		from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-		to := time.Date(2024, 3, 2, 0, 0, 0, 0, time.UTC) // 61 days
+		to := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC) // 366 days
 		period := &Period{From: from, To: to}
 
 		result, err := svc.GetAccountEgress(context.Background(), accountDID, nil, period)
@@ -275,7 +275,7 @@ func TestGetAccountEgress(t *testing.T) {
 		require.Nil(t, result)
 		var periodErr ErrPeriodNotAcceptable
 		require.ErrorAs(t, err, &periodErr)
-		assert.Contains(t, periodErr.msg, "60 days")
+		assert.Contains(t, periodErr.msg, "365 days")
 	})
 
 	t.Run("successfully returns empty result for account with no spaces", func(t *testing.T) {


### PR DESCRIPTION
Allow querying egress data for 365 days, which is what we show in the Dashboard view of the customer dashboard.

This should be manageable because the `spacestats` table is keyed by space+date, and egress is accumulated daily, so the query returns at most 365 results per space.

There's an actual risk coming from accounts with lots of spaces (likely not an issue below 100 spaces), because those are queried serially. I created #41 so that we don't lose track of this.